### PR TITLE
Fix environment config for BCM-SDK

### DIFF
--- a/envs/bcm-sdk.sh
+++ b/envs/bcm-sdk.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-ln -sf ~/am-toolchains/brcm-arm-sdk/hndtools-arm-linux-2.6.36-uclibc-4.5.3 /opt/brcm-arm
+sudo ln -sf ~/am-toolchains/brcm-arm-sdk/hndtools-arm-linux-2.6.36-uclibc-4.5.3 /opt/brcm-arm
+ln -sf ~/am-toolchains/brcm-arm-sdk  /build/release/src-rt-6.x.4708/toolchains
 
 export LD_LIBRARY_PATH=$LD_LIBRARY:/opt/brcm-arm/lib
 export PATH=$PATH:/opt/brcm-arm/bin


### PR DESCRIPTION
Per [toolchain docs](https://github.com/RMerl/am-toolchains#bcm-sdk), the in-repo toolchain link in the firmware source's `release/.../toolchain` needs to point back to the appropriate location.

Without this, the cross-compiler `cc1` doesn't find its dynamic library dependency `libmpc.so.2` (regardless of `LD_LIBRARY_PATH`!!), which it locates via that symlink.

I discovered this after many hours of debugging :(

Also, prefix the first symlink creation with `sudo`, since it modifies a root-owned location.