### PR TITLE
feat: add hexdump from bsdmainutils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN \
       lib32z1-dev lib32stdc++6 xsltproc gtk-doc-tools libelf-dev:i386      \
       libelf1:i386 libltdl-dev openssh-server curl nano lzip patchelf      \
       automake gosu bc rsync sudo xxd python-is-python2 execstack gdisk    \
-      gengetopt &&                                                         \
+      gengetopt bsdmainutils &&                                            \
 
     # Clean up env
     apt -y autoremove && \


### PR DESCRIPTION
This is required when building cfe for converting .html files into .c sources